### PR TITLE
WinPE: improve BitLocker unlock + disk health workflow

### DIFF
--- a/payloads/WinPECollector/WinPE-Collector.ps1
+++ b/payloads/WinPECollector/WinPE-Collector.ps1
@@ -415,6 +415,7 @@ function Get-ThumbDriveRoot {
 }
 
 function Test-VolumeNeedsRepair {
+    [OutputType([System.Boolean])]
     <#
     .SYNOPSIS
         Validates if a volume object indicates filesystem health issues that may require repair.
@@ -466,6 +467,7 @@ function Test-VolumeNeedsRepair {
 }
 
 function Invoke-DiskHealthWorkflow {
+    [OutputType([System.Boolean])]
     <#
     .SYNOPSIS
     Performs a comprehensive disk health assessment and optionally repairs detected issues.


### PR DESCRIPTION
Add WINPE_DIAG thumbdrive detection for BL_Keys.txt
Run post-unlock diagnostics for key-file unlock path
Fix manage-bde parsing to avoid false “encrypted” detection
Redact recovery keys from logs; clarify repair menu text